### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/mattn/mkup
+
+go 1.13
+
+require (
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/omeid/livereload v0.0.0-20180903043807-18d58b752b26
+	github.com/russross/blackfriday v1.5.2
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7
+)


### PR DESCRIPTION
I added go.mod file because I cannot build this repository without go.mod. But I could not build even when I create go.mod by "go mod init" as it is. So I'm modifying blackfriday's version to specify to V1.5.2. This modification is just for being buildable.

When I build without go.mod or using default go.mod file below error is happened:
```
go\pkg\mod\github.com\mattn\mkup@v0.0.0-20170625073151-4e37e2c0eb61\main.go:45:15: undefined: blackfriday.EXTENSION_NO_INTRA_EMPHASIS
go\pkg\mod\github.com\mattn\mkup@v0.0.0-20170625073151-4e37e2c0eb61\main.go:46:3: undefined: blackfriday.EXTENSION_TABLES
go\pkg\mod\github.com\mattn\mkup@v0.0.0-20170625073151-4e37e2c0eb61\main.go:47:3: undefined: blackfriday.EXTENSION_FENCED_CODE
go\pkg\mod\github.com\mattn\mkup@v0.0.0-20170625073151-4e37e2c0eb61\main.go:48:3: undefined: blackfriday.EXTENSION_AUTOLINK
go\pkg\mod\github.com\mattn\mkup@v0.0.0-20170625073151-4e37e2c0eb61\main.go:49:3: undefined: blackfriday.EXTENSION_STRIKETHROUGH
go\pkg\mod\github.com\mattn\mkup@v0.0.0-20170625073151-4e37e2c0eb61\main.go:50:3: undefined: blackfriday.EXTENSION_SPACE_HEADERS
go\pkg\mod\github.com\mattn\mkup@v0.0.0-20170625073151-4e37e2c0eb61\main.go:144:15: undefined: blackfriday.HtmlRenderer
go\pkg\mod\github.com\mattn\mkup@v0.0.0-20170625073151-4e37e2c0eb61\main.go:145:27: too many arguments to conversion to blackfriday.Markdown: blackfriday.Markdown(b, renderer, extensions)
```