### PR TITLE
livereload.js が使うポートを http serve が使う TCP ポートを併用するように修正

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/mattn/mkup
 
-go 1.17
+go 1.24.0
+
+toolchain go1.24.9
 
 require (
 	github.com/omeid/livereload v0.0.0-20180903043807-18d58b752b26
@@ -11,6 +13,6 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+	golang.org/x/sys v0.39.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/omeid/livereload v0.0.0-20180903043807-18d58b752b26 h1:UgrpxortNaAijXWp2dVezOb/2lVNtGlaI/y6SAosQds=
 github.com/omeid/livereload v0.0.0-20180903043807-18d58b752b26/go.mod h1:zwZKGxj+J+XPXOcKyE1ByX0oRLb+iWZwy4wO7W9LHTM=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
@@ -11,5 +13,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/main.go
+++ b/main.go
@@ -56,7 +56,8 @@ const (
 )
 
 var (
-	addr = flag.String("http", ":8000", "HTTP service address (e.g., ':8000')")
+	addr        = flag.String("http", ":8000", "HTTP service address (e.g., ':8000')")
+	usehttpport = flag.Bool("usehttpport", false, "use livereload port with the same http port")
 )
 
 //go:embed _assets
@@ -153,6 +154,21 @@ func main() {
 			log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL.RequestURI())
 			http.DefaultServeMux.ServeHTTP(w, r)
 		}),
+	}
+
+	if *usehttpport == false {
+		go func() {
+			addr := ":35729"
+			server := &http.Server{
+				Addr: addr,
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL.RequestURI())
+					http.DefaultServeMux.ServeHTTP(w, r)
+				}),
+			}
+			fmt.Fprintln(os.Stderr, "Listening at "+addr)
+			server.ListenAndServe()
+		}()
 	}
 
 	fmt.Fprintln(os.Stderr, "Listening at "+*addr)

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"embed"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"mime"
 	"net/http"
@@ -124,7 +123,7 @@ func main() {
 			fs.ServeHTTP(w, r)
 			return
 		}
-		b, err := ioutil.ReadFile(filepath.Join(cwd, name))
+		b, err := os.ReadFile(filepath.Join(cwd, name))
 		if err != nil {
 			if os.IsNotExist(err) {
 				http.Error(w, "404 page not found", 404)

--- a/main.go
+++ b/main.go
@@ -38,8 +38,8 @@ const (
 <script src="/_assets/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>
 <script>document.write('<script src="http://'
-    + (location.host || 'localhost').split(':')[0]
-    + ':35729/livereload.js?snipver=1"></'
+    + (location.host || 'localhost')
+    + '/_assets/livereload.js?snipver=1"></'
     + 'script>')</script>
 </head>
 <body>
@@ -69,22 +69,6 @@ func main() {
 
 	lrs := livereload.New("mkup")
 	defer lrs.Close()
-
-	go func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/livereload.js", func(w http.ResponseWriter, r *http.Request) {
-			b, err := local.ReadFile("_assets/livereload.js")
-			if err != nil {
-				http.Error(w, "404 page not found", 404)
-				return
-			}
-			w.Header().Set("Content-Type", "application/javascript")
-			w.Write(b)
-			return
-		})
-		mux.Handle("/", lrs)
-		log.Fatal(http.ListenAndServe(":35729", mux))
-	}()
 
 	fsw, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -157,6 +141,7 @@ func main() {
 		)
 		w.Write([]byte(fmt.Sprintf(template, name, string(b))))
 	})
+	http.Handle("/livereload", lrs)
 
 	server := &http.Server{
 		Addr: *addr,

--- a/main.go
+++ b/main.go
@@ -141,7 +141,11 @@ func main() {
 		)
 		w.Write([]byte(fmt.Sprintf(template, name, string(b))))
 	})
-	http.Handle("/livereload", lrs)
+	http.Handle("/livereload",
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				lrs.ServeHTTP(w, r)
+			}))
 
 	server := &http.Server{
 		Addr: *addr,


### PR DESCRIPTION
変な動きしていたところは直りました。
これで、 livereload.js が使うポートを http serve が使う TCP ポートを併用するように修正できたと思います。
よろしくお願いします。